### PR TITLE
Fix stray char in stat_tools docstring

### DIFF
--- a/stat_tools.py
+++ b/stat_tools.py
@@ -317,7 +317,7 @@ def compute_group_iqr(
     stage_col: str   = "Этап регистрации",
     group_col: str   = "После приема"
 ) -> pd.DataFrame:
-    """f
+    """
     Считает для каждой из групп T/R и для двух этапов (baseline = Скрининг, followup = Период 2)
     квартили Q1, медиану и Q3 по параметру param_col и возвращает DataFrame
     с колонками [group_col, stage, q1, median, q3].


### PR DESCRIPTION
## Summary
- remove extra `f` character from the `compute_group_iqr` docstring in `stat_tools.py`

## Testing
- `python -m py_compile app.py blood_analysis.py docx_tools.py loader.py pk.py stat_tools.py viz.py`

------
https://chatgpt.com/codex/tasks/task_e_6842db1a47848331a82f2ae9003c37df