### PR TITLE
Add loader and stats tests

### DIFF
--- a/tests/test_blood.py
+++ b/tests/test_blood.py
@@ -1,0 +1,68 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+import numpy as np
+
+from blood_analysis import extract_oak_pairwise, extract_individual_lab
+from stat_tools import compute_group_dynamics, compute_group_iqr, compute_vitals_iqr
+
+
+def test_extract_oak_pairwise():
+    df = pd.DataFrame({
+        "№ п/п": [1, 1, 2, 2],
+        "Этап регистрации": ["Скрининг", "в конце периода 2", "Скрининг", "в конце периода 2"],
+        "Гемоглобин, г/л": [100, 120, 110, 130],
+    })
+    res = extract_oak_pairwise(df, "Гемоглобин, г/л")
+    assert list(res.columns) == ["Subject", "Before", "After"]
+    assert len(res) == 2
+    assert res.loc[0, "Before"] == 100
+    assert res.loc[0, "After"] == 120
+
+
+def test_extract_individual_lab_parse_range():
+    df = pd.DataFrame({
+        "№ п/п": [1, 1, 2, 2],
+        "Этап регистрации": ["Скрининг", "Период 2 - в конце", "Скрининг", "Период 2 - в конце"],
+        "После приема": ["T", "T", "R", "R"],
+        "АЛТ": ["10-20", 25, 15, 30],
+    })
+    res = extract_individual_lab(df, "АЛТ", subject_col="№ п/п", group_col="После приема")
+    assert len(res) == 2
+    assert np.isclose(res.loc[0, "before"], 15)
+    assert res.loc[0, "after"] == 25
+
+
+def test_compute_group_dynamics():
+    df = pd.DataFrame({
+        "№ п/п": [1, 1, 2, 2],
+        "Этап регистрации": ["Скрининг", "Период 2 - в конце", "Скрининг", "Период 2 - в конце"],
+        "После приема": ["T", "T", "R", "R"],
+        "ALT": [10, 20, 10, 15],
+    })
+    res = compute_group_dynamics(df, "ALT", subject_col="№ п/п", stage_col="Этап регистрации", group_col="После приема")
+    assert list(res.columns) == ["После приема", "baseline", "followup"]
+    assert np.isclose(res.loc[0, "baseline"], 10)
+
+
+def test_compute_group_iqr():
+    df = pd.DataFrame({
+        "№ п/п": [1, 1, 2, 2],
+        "Этап регистрации": ["Скрининг", "Период 2", "Скрининг", "Период 2"],
+        "После приема": ["T", "T", "R", "R"],
+        "ALT": [10, 20, 15, 30],
+    })
+    res = compute_group_iqr(df, "ALT", subject_col="№ п/п", stage_col="Этап регистрации", group_col="После приема")
+    stages = set(res["stage"])
+    assert {"baseline", "followup"} <= stages
+
+
+def test_compute_vitals_iqr():
+    df = pd.DataFrame({
+        "Препарат": ["T", "T", "R", "R"],
+        "Этап регистрации": ["A", "A", "A", "A"],
+        "param": [1.0, 2.0, 3.0, 4.0],
+    })
+    res = compute_vitals_iqr(df, "param")
+    assert len(res) == 2
+    assert set(res.columns) == {"Препарат", "Этап регистрации", "q1", "median", "q3"}

--- a/tests/test_docx_tools.py
+++ b/tests/test_docx_tools.py
@@ -1,0 +1,45 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import pandas as pd
+import numpy as np
+from pathlib import Path
+
+from docx_tools import (
+    cv_log,
+    export_power_analysis_table,
+    export_individual_pk_tables,
+)
+
+
+def test_cv_log_invalid():
+    s = pd.Series([1.0, 0.0, 2.0])
+    assert np.isnan(cv_log(s))
+
+
+def test_export_power_analysis_table(tmp_path):
+    out = tmp_path / "power.docx"
+    path = export_power_analysis_table([1.0, 1.0, 1.0], [10, 20, 30], n=12, save_path=str(out))
+    assert Path(path).is_file()
+
+
+def test_export_individual_pk_tables(tmp_path):
+    df = pd.DataFrame({
+        "Subject": [1, 2],
+        "Treatment": ["Test", "Ref"],
+        "AUC0-t": [100, 110],
+        "AUC0-inf": [120, 130],
+        "Cmax": [10, 9],
+        "Tmax": [1, 1],
+        "T1/2": [2.0, 2.1],
+        "Kel": [0.3, 0.3],
+        "N_el": [5, 5],
+        "MRT": [12, 13],
+        "Tlag": [0, 0],
+        "Vd": [20, 21],
+        "CL": [1.0, 1.1],
+    })
+    out = tmp_path / "ind_pk.docx"
+    path = export_individual_pk_tables(df, "Tst", "Ref", "Sub", 100, 100, save_path=str(out))
+    assert Path(path).is_file()
+

--- a/tests/test_pk.py
+++ b/tests/test_pk.py
@@ -1,0 +1,75 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+import numpy as np
+from pk import calc_auc, calc_kel, compute_pk
+
+
+def make_simple_df():
+    times = [0, 1, 2, 3, 4, 5]
+    concs = [0, 10, 8, 6, 4, 2]
+    data = []
+    for t, c in zip(times, concs):
+        data.append({
+            'Subject': 1,
+            'Sequence': 'TR',
+            'Period': 1,
+            'Treatment': 'Test',
+            'Time': t,
+            'Concentration': c
+        })
+    return pd.DataFrame(data)
+
+
+# ---- calc_auc -------------------------------------------------------------
+
+def test_calc_auc_simple():
+    auc = calc_auc([0, 1, 2], [0, 2, 0])
+    assert auc == 2
+
+def test_calc_auc_unsorted():
+    auc = calc_auc([2, 0, 1], [0, 0, 2])
+    assert auc == 2
+
+# ---- calc_kel -------------------------------------------------------------
+
+def test_calc_kel():
+    concs = [0, 10, 8, 6, 4, 2]
+    times = [0, 1, 2, 3, 4, 5]
+    kel, t_half, n = calc_kel(concs, times, min_points=4)
+    assert np.isclose(kel, 0.3912023, atol=1e-6)
+    assert np.isclose(t_half, 1.7718382, atol=1e-6)
+    assert n == 5
+
+def test_calc_kel_insufficient_total():
+    concs = [0, 0.5, 0.4]
+    times = [0, 1, 2]
+    kel, t_half, n = calc_kel(concs, times, min_points=4)
+    assert np.isnan(kel) and np.isnan(t_half)
+    assert n == 0
+
+def test_calc_kel_insufficient_post_tmax():
+    concs = [1, 2, 3, 2, 1]
+    times = [0, 1, 2, 3, 4]
+    kel, t_half, n = calc_kel(concs, times, min_points=4, lloq=0.5)
+    assert np.isnan(kel) and np.isnan(t_half)
+    assert n == 3  # points after Tmax
+
+# ---- compute_pk -----------------------------------------------------------
+
+def test_compute_pk_single():
+    df = make_simple_df()
+    pk_table = compute_pk(df)
+    row = pk_table.iloc[0]
+    assert row['Cmax'] == 10
+    assert row['Tmax'] == 1
+    assert np.isclose(row['AUC0-t'], 29.0)
+    assert np.isclose(row['AUC0-inf'], 34.112444, atol=1e-6)
+
+def test_compute_pk_no_positive():
+    df = make_simple_df()
+    df['Concentration'] = 0.0
+    pk_table = compute_pk(df)
+    row = pk_table.iloc[0]
+    assert row[['Cmax','Tmax','AUC0-t','AUC0-inf','Kel','T1/2','N_el','CL','Vd','MRT','Tlag']].isna().all()
+

--- a/tests/test_stats_extra.py
+++ b/tests/test_stats_extra.py
@@ -1,0 +1,70 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+import numpy as np
+
+from stat_tools import (
+    ci_calc,
+    calc_swr,
+    make_stat_report_table,
+    add_mse_se_to_pivot,
+    identify_be_outlier_and_recommend,
+    generate_conclusions,
+)
+
+
+def test_ci_calc_basic():
+    log_diff = pd.Series([0.0, np.log(2)])
+    ratio, lo, hi = ci_calc(log_diff)
+    assert ratio > 1
+    assert lo < ratio < hi
+
+
+def test_calc_swr():
+    logs = np.log([1.0, 2.0, 4.0])
+    swr, cv = calc_swr(logs)
+    assert swr > 0
+    assert cv > 0
+
+
+def test_make_stat_report_table():
+    df = make_stat_report_table([1.0, 1.1, 1.2], [0.9, 1.0, 1.1], [1.1, 1.2, 1.3], [10, 15, 20])
+    assert df.shape[0] == 3
+    assert "90% ДИ" in df.columns
+
+
+def test_add_mse_se_to_pivot():
+    pivot = pd.DataFrame({"log_Cmax_diff": [0.1, 0.2, 0.3]})
+    res = add_mse_se_to_pivot(pivot)
+    assert "MSE_log_Cmax" in res.columns
+    assert "SE_log_Cmax" in res.columns
+
+
+def test_identify_be_outlier_and_recommend():
+    df_conc = pd.DataFrame({
+        "Subject": [1, 1, 2, 2],
+        "Time": [0, 1, 0, 1],
+        "Treatment": ["Test", "Test", "Test", "Test"],
+        "Concentration": [10, 20, 10, 30],
+    })
+    pk_df = pd.DataFrame({
+        "Subject": [1, 1, 2, 2],
+        "Treatment": ["Test", "Ref", "Test", "Ref"],
+        "Cmax": [100, 80, 80, 80],
+    })
+    outlier, rec_df = identify_be_outlier_and_recommend(df_conc, pk_df, "Cmax", 0.7, 0.9)
+    assert outlier == 1
+    assert set(rec_df.columns) == {"Subject", "Time", "Recommended_Concentration"}
+
+
+def test_generate_conclusions():
+    df = pd.DataFrame({
+        "Subject": [1, 2],
+        "group": ["T", "R"],
+        "before": [10, 20],
+        "after": [15, 10],
+    })
+    res = generate_conclusions(df, "ALT")
+    assert res["T"]
+    assert res["R"]
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,84 @@
+import os
+import pytest
+import pandas as pd
+import numpy as np
+from io import StringIO, BytesIO
+
+from loader import load_randomization, load_timepoints, parse_excel_files
+from src.data_loader import load_data, DataLoaderError
+from stat_tools import log_diff_stats
+from docx_tools import cv_log
+
+def test_load_randomization_and_timepoints(tmp_path):
+    rand_csv = "Subject,Sequence\n1,TR\n2,RT\n"
+    rand_file = tmp_path / "rand.csv"
+    rand_file.write_text(rand_csv, encoding="utf-8")
+
+    time_csv = "Code,Time\n00,0\n01,1\n"
+    time_file = tmp_path / "time.csv"
+    time_file.write_text(time_csv, encoding="utf-8")
+
+    rand = load_randomization(rand_file)
+    times = load_timepoints(time_file)
+    assert rand == {1: "TR", 2: "RT"}
+    assert times == {"00": 0, "01": 1}
+
+def make_ct_excel(path):
+    df = pd.DataFrame({
+        "Subject": [1, 2],
+        "Time": [1, 1],
+        "Concentration, Period 1": [10, 0],
+        "Concentration, Period 2": [0, 10],
+    })
+    with pd.ExcelWriter(path) as writer:
+        df.to_excel(writer, sheet_name="CT", index=False, startrow=28)
+
+def test_parse_excel_files_ct(tmp_path):
+    xls_path = tmp_path / "sample.xlsx"
+    make_ct_excel(xls_path)
+    rand = {1: "TR", 2: "RT"}
+    time_dict = {"01": 1}
+    df = parse_excel_files([str(xls_path)], rand, time_dict)
+    assert len(df) == 4
+    assert set(df["Treatment"]) == {"Test", "Ref"}
+
+def test_data_loader_success(tmp_path):
+    rand_file = tmp_path / "rand.csv"
+    rand_file.write_text("Subject,Sequence\n1,TR\n2,RT\n", encoding="utf-8")
+    time_file = tmp_path / "time.csv"
+    time_file.write_text("Code,Time\n01,1\n", encoding="utf-8")
+    xls_path = tmp_path / "data.xlsx"
+    make_ct_excel(xls_path)
+    df, rand_dict, time_dict = load_data(rand_file, time_file, [str(xls_path)])
+    assert df.shape[0] == 4
+    assert rand_dict[1] == "TR" and rand_dict[2] == "RT"
+    assert time_dict == {"01": 1}
+
+def test_data_loader_sequence_mismatch(tmp_path):
+    rand_file = tmp_path / "rand.csv"
+    rand_file.write_text("Subject,Sequence\n1,TR\n2,TR\n", encoding="utf-8")
+    time_file = tmp_path / "time.csv"
+    time_file.write_text("Code,Time\n01,1\n", encoding="utf-8")
+    xls_path = tmp_path / "data.xlsx"
+    make_ct_excel(xls_path)
+    with pytest.raises(DataLoaderError):
+        load_data(rand_file, time_file, [str(xls_path)])
+
+def test_log_diff_stats():
+    df = pd.DataFrame({
+        "Cmax_Test": [2.0],
+        "Cmax_Ref": [1.0],
+        "AUC0-t_Test": [2.0],
+        "AUC0-t_Ref": [1.0],
+        "AUC0-inf_Test": [2.0],
+        "AUC0-inf_Ref": [1.0],
+    })
+    res = log_diff_stats(df.copy())
+    assert np.isclose(res.loc[0, "log_Cmax_diff"], np.log(2))
+    assert np.isclose(res.loc[0, "log_AUC0-t_diff"], np.log(2))
+    assert np.isclose(res.loc[0, "log_AUC0-inf_diff"], np.log(2))
+
+def test_cv_log():
+    s = pd.Series([1.0, 2.0, 3.0])
+    cv = cv_log(s)
+    assert cv > 0


### PR DESCRIPTION
## Summary
- create new pytest suite covering loader utilities, data loader logic, and statistical helpers
- exercise CT-format Excel parsing and DataLoaderError

## Testing
- `pip install --progress-bar off pandas numpy scipy statsmodels matplotlib python-docx openpyxl`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843109f1b948331b542fa855d1ed21b