### PR TITLE
Add subject exclusion

### DIFF
--- a/app.py
+++ b/app.py
@@ -140,6 +140,12 @@ if rand_file and time_file and xlsx_files:
     st.success(f"Загружено значений: {len(df)}")
     st.dataframe(df.head())
 
+    subjects = sorted(df["Subject"].astype(str).unique())
+    excluded = st.sidebar.multiselect("Исключить добровольцев", subjects)
+    if excluded:
+        df = df[~df["Subject"].astype(str).isin(excluded)]
+        st.info("Исключены добровольцы: " + ", ".join(excluded))
+
     try:
         pk_table, pivot, stats = compute_pk_and_stats(df, dose_test=dose_test, dose_ref=dose_ref)
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.29.1
+streamlit>=1.29
 pandas>=1.5.0
 numpy>=1.23.0
 scipy>=1.9.0

--- a/tests/test_app_e2e.py
+++ b/tests/test_app_e2e.py
@@ -11,6 +11,7 @@ class DummyFile:
 
 def make_app(monkeypatch, tmp_path):
     monkeypatch.setattr(st.sidebar, "file_uploader", lambda *a, **k: DummyFile() if not k.get('accept_multiple_files') else [DummyFile()])
+    monkeypatch.setattr(st.sidebar, "multiselect", lambda *a, **k: [])
     monkeypatch.setattr(st, "file_uploader", lambda *a, **k: DummyFile())
     monkeypatch.setattr(pd.DataFrame, "style", property(lambda self: types.SimpleNamespace(format=lambda *a, **k: self)))
 

--- a/tests/test_app_import.py
+++ b/tests/test_app_import.py
@@ -12,6 +12,8 @@ class DummySidebar:
         return None
     def checkbox(self, *a, **k):
         return False
+    def multiselect(self, *a, **k):
+        return []
     def subheader(self, *a, **k):
         pass
     def header(self, *a, **k):

--- a/tests/test_app_run.py
+++ b/tests/test_app_run.py
@@ -20,6 +20,8 @@ class DummySidebar:
         return options[0]
     def checkbox(self, label, **kw):
         return False
+    def multiselect(self, label, options, **kw):
+        return []
     def subheader(self, *a, **k):
         pass
     def header(self, *a, **k):


### PR DESCRIPTION
## Summary
- add UI option to exclude subjects from PK analysis
- patch Streamlit dummies in tests for new widget
- relax streamlit dependency version for install

## Testing
- `pytest --cov=. --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_6862b9b408388331971f9ccc88865608