### PR TITLE
Fix duplicate parameters in plot_mean_curves

### DIFF
--- a/viz.py
+++ b/viz.py
@@ -108,23 +108,10 @@ def plot_mean_curves(
     mean_df,
     test_name="Test",
     ref_name="Reference",
-
     *,
     logscale=False,
     xticks=None,
     xlog=False,
-
-    logscale=False,
-    xticks=None,
-
-    xlog=False,
-
-
-    xlog=False,
-
-
-
-
 ):
     fig, ax = plt.subplots(figsize=(8, 5))
 


### PR DESCRIPTION
## Summary
- correct parameter list for `plot_mean_curves` in `viz.py`
- run the full test suite

## Testing
- `pytest --cov=. --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_68630af66c6c8331b6b5180001d08afe