### PR TITLE
Fix mean_curves helper

### DIFF
--- a/src/plot_utils.py
+++ b/src/plot_utils.py
@@ -28,6 +28,7 @@ def individual_profile(df, subj, test_name, ref_name, log=False):
 
 
 def mean_curves(df, test_name, ref_name, log=False, times=None, xlog=False):
+    """Wrapper around :func:`plot_mean_curves` with keyword-only arguments."""
     return plot_mean_curves(
         df,
         test_name,
@@ -36,11 +37,6 @@ def mean_curves(df, test_name, ref_name, log=False, times=None, xlog=False):
         xticks=times,
         xlog=xlog,
     )
-
-
-
-def mean_curves(df, test_name, ref_name, log=False, times=None):
-    return plot_mean_curves(df, test_name, ref_name, logscale=log, xticks=times)
 
 
 

--- a/viz.py
+++ b/viz.py
@@ -108,23 +108,10 @@ def plot_mean_curves(
     mean_df,
     test_name="Test",
     ref_name="Reference",
-
     *,
     logscale=False,
     xticks=None,
     xlog=False,
-
-    logscale=False,
-    xticks=None,
-
-    xlog=False,
-
-
-    xlog=False,
-
-
-
-
 ):
     fig, ax = plt.subplots(figsize=(8, 5))
 


### PR DESCRIPTION
## Summary
- remove duplicate `mean_curves` definition in `plot_utils`
- run the full test suite

## Testing
- `pytest --cov=. --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_68630af66c6c8331b6b5180001d08afe